### PR TITLE
Prepare for release v2020.07.09-beta.0

### DIFF
--- a/charts/csi-vault-community/Chart.yaml
+++ b/charts/csi-vault-community/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: csi-vault-community
 description: CSI Vault Community Plan
 type: application
-version: v0.3.0
-appVersion: v0.3.0
+version: v2020.07.09-beta.0
+appVersion: v2020.07.09-beta.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:
-  - https://github.com/kubevault
+- https://github.com/kubevault
 maintainers:
-  - name: appscode
-    email: support@appscode.com
+- name: appscode
+  email: support@appscode.com

--- a/charts/csi-vault-community/templates/bundle.yaml
+++ b/charts/csi-vault-community/templates/bundle.yaml
@@ -24,5 +24,5 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.3.0
+      - version: v0.4.0-beta.0
 status: {}

--- a/charts/vault-operator-community/Chart.yaml
+++ b/charts/vault-operator-community/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: vault-operator-community
 description: Vault Operator Community Plan
 type: application
-version: v0.3.0
-appVersion: v0.3.0
+version: v2020.07.09-beta.0
+appVersion: v2020.07.09-beta.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:
-  - https://github.com/kubevault
+- https://github.com/kubevault
 maintainers:
-  - name: appscode
-    email: support@appscode.com
+- name: appscode
+  email: support@appscode.com

--- a/charts/vault-operator-community/templates/bundle.yaml
+++ b/charts/vault-operator-community/templates/bundle.yaml
@@ -24,7 +24,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.3.0
+      - version: v0.4.0-beta.0
   - chart:
       features:
       - Vault Catalog by AppsCode - Catalog for Vault versions
@@ -32,9 +32,9 @@ spec:
       required: true
       url: https://charts.appscode.com/stable/
       versions:
-      - version: v0.3.0
+      - version: v0.4.0-beta.0
   - bundle:
       name: csi-vault-community
       url: https://bundles.byte.builders/stable
-      version: v0.3.0
+      version: v2020.07.09-beta.0
 status: {}


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2020.07.09-beta.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/3
Signed-off-by: 1gtm <1gtm@appscode.com>