### PR TITLE
Prepare for release v2022.09.22

### DIFF
--- a/charts/csi-vault-community/Chart.yaml
+++ b/charts/csi-vault-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: csi-vault-community
 description: CSI Vault Community Plan
 type: application
-version: v2022.09.09
-appVersion: v2022.09.09
+version: v2022.09.22
+appVersion: v2022.09.22
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/vault-operator-community/Chart.yaml
+++ b/charts/vault-operator-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vault-operator-community
 description: Vault Operator Community Plan
 type: application
-version: v2022.09.09
-appVersion: v2022.09.09
+version: v2022.09.22
+appVersion: v2022.09.22
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/vault-operator-community/templates/bundle.yaml
+++ b/charts/vault-operator-community/templates/bundle.yaml
@@ -36,5 +36,5 @@ spec:
   - bundle:
       name: csi-vault-community
       url: https://bundles.byte.builders/stable
-      version: v2022.09.09
+      version: v2022.09.22
 status: {}


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.09.22
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/31
Signed-off-by: 1gtm <1gtm@appscode.com>