### PR TITLE
Prepare for release v2023.9.7

### DIFF
--- a/charts/csi-vault-community/Chart.yaml
+++ b/charts/csi-vault-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: csi-vault-community
 description: CSI Vault Community Plan
 type: application
-version: v2023.05.05
-appVersion: v2023.05.05
+version: v2023.9.7
+appVersion: v2023.9.7
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/vault-operator-community/Chart.yaml
+++ b/charts/vault-operator-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vault-operator-community
 description: Vault Operator Community Plan
 type: application
-version: v2023.05.05
-appVersion: v2023.05.05
+version: v2023.9.7
+appVersion: v2023.9.7
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/vault-operator-community/templates/bundle.yaml
+++ b/charts/vault-operator-community/templates/bundle.yaml
@@ -36,5 +36,5 @@ spec:
   - bundle:
       name: csi-vault-community
       url: https://bundles.byte.builders/stable
-      version: v2023.05.05
+      version: v2023.9.7
 status: {}


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2023.9.7
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/45
Signed-off-by: 1gtm <1gtm@appscode.com>