### PR TITLE
Prepare for release v2024.1.26-rc.0

### DIFF
--- a/charts/csi-vault-community/Chart.yaml
+++ b/charts/csi-vault-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: csi-vault-community
 description: CSI Vault Community Plan
 type: application
-version: v2023.9.7
-appVersion: v2023.9.7
+version: v2024.1.26-rc.0
+appVersion: v2024.1.26-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/csi-vault-community/templates/bundle.yaml
+++ b/charts/csi-vault-community/templates/bundle.yaml
@@ -22,7 +22,8 @@ spec:
       - HashiCorp Vault CSI Driver for Kubernetes
       name: csi-vault
       required: true
-      url: https://charts.appscode.com/stable/
+      sourceRef:
+        name: ""
       versions:
       - version: v0.4.0-rc.0
 status: {}

--- a/charts/vault-operator-community/Chart.yaml
+++ b/charts/vault-operator-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vault-operator-community
 description: Vault Operator Community Plan
 type: application
-version: v2023.9.7
-appVersion: v2023.9.7
+version: v2024.1.26-rc.0
+appVersion: v2024.1.26-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/vault-operator-community/templates/bundle.yaml
+++ b/charts/vault-operator-community/templates/bundle.yaml
@@ -22,7 +22,8 @@ spec:
       - Vault Operator by AppsCode - HashiCorp Vault Operator for Kubernetes
       name: vault-operator
       required: true
-      url: https://charts.appscode.com/stable/
+      sourceRef:
+        name: ""
       versions:
       - version: v0.4.0-beta.0
   - chart:
@@ -30,11 +31,13 @@ spec:
       - Vault Catalog by AppsCode - Catalog for Vault versions
       name: vault-catalog
       required: true
-      url: https://charts.appscode.com/stable/
+      sourceRef:
+        name: ""
       versions:
       - version: v0.4.0-beta.0
   - bundle:
       name: csi-vault-community
-      url: https://bundles.byte.builders/stable
-      version: v2023.9.7
+      sourceRef:
+        name: ""
+      version: v2024.1.26-rc.0
 status: {}


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.1.26-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/46
Signed-off-by: 1gtm <1gtm@appscode.com>