### PR TITLE
Prepare for release v2024.1.28-rc.1

### DIFF
--- a/charts/csi-vault-community/Chart.yaml
+++ b/charts/csi-vault-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: csi-vault-community
 description: CSI Vault Community Plan
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/vault-operator-community/Chart.yaml
+++ b/charts/vault-operator-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vault-operator-community
 description: Vault Operator Community Plan
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/vault-operator-community/templates/bundle.yaml
+++ b/charts/vault-operator-community/templates/bundle.yaml
@@ -39,5 +39,5 @@ spec:
       name: csi-vault-community
       sourceRef:
         name: ""
-      version: v2024.1.26-rc.0
+      version: v2024.1.28-rc.1
 status: {}


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.1.28-rc.1
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/47
Signed-off-by: 1gtm <1gtm@appscode.com>